### PR TITLE
Re-throw PHPParser_Error

### DIFF
--- a/src/PHPSandbox/PHPSandbox.php
+++ b/src/PHPSandbox/PHPSandbox.php
@@ -6294,7 +6294,7 @@
             try {
                 $this->parsed_ast = $parser->parse($this->preparsed_code);
             } catch (\PHPParser_Error $error) {
-                throw new Error($error);
+                throw new Error($error, 0, $error);
             }
 
             $prettyPrinter = new \PHPParser_PrettyPrinter_Default;


### PR DESCRIPTION
PHPParser_Error has really interesting information in it, like the proper error message and line number, which gets lost in a (string)$e conversion.

Setting it as the third param means we can access it with $e->getPrevious()
