### PR TITLE
Declare a variable explicitly in order to prevent from E_NOTICE

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -41,7 +41,7 @@
     function &wrapByRef(&$value, $sandbox){
         if(!($value instanceof SandboxedString) && is_object($value) && method_exists($value, '__toString')){
             $strval = $value->__toString();
-            return is_callable($strval) ? new SandboxedString($strval, $sandbox) : $value;
+            return is_callable($strval) ? ($_ = new SandboxedString($strval, $sandbox)) : $value;
         } else if(is_array($value) && count($value)){
             //save current array pointer
             $current_key = key($value);
@@ -56,7 +56,7 @@
             }
             return $value;
         } else if(is_string($value) && is_callable($value)){
-            return new SandboxedString($value, $sandbox);
+            return ($_ = new SandboxedString($value, $sandbox));
         }
         return $value;
     }


### PR DESCRIPTION
We have a lot of notices like the following one:
```
PHP Notice:  Only variable references should be returned by reference in /path_to_project/vendor/fieryprophet/php-sandbox/src/functions.php on line 44
```

We are running php 5.6:
```
php -v
PHP 5.6.5 (cli) (built: Jan 21 2015 17:50:29)
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2014 Zend Technologies
    with Zend OPcache v7.0.4-dev, Copyright (c) 1999-2014, by Zend Technologies
```

Looks like php does not like `return new Foo()` in functions like `&wrapByRef` and wants some variable to be returned instead.