### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,24 @@
-#CHANGELOG
+# CHANGELOG
 
-##04/24/2015
+## 04/24/2015
 - Added the optional ability to sandbox included files and added two flags for this functionality: allow_includes to allow the sandbox to utilize included files, which is disabled by default, and sandbox_includes to sandbox all included files with the current sandbox instance if allow_includes is enabled, which is enabled by default. User-created functions may also be defined in place of the default include(), require(), etc. methods utilized by the sandbox using the define_func() API. Finally, the include keyword is no longer blacklisted by default.
 
-##02/27/2015
+## 02/27/2015
 - Addressed issue #18 where arrays may potentially allow for compromising the sandbox by encapsulating unsandboxed callables
 
-##07/24/2014
+## 07/24/2014
 - Fixed bug with prepare_vars()
 
-##06/19/2014
+## 06/19/2014
 - Added flags to enable/disable validation checks for every type (for example, this will help in situations where someone wants to enable all functions but not blacklist a fake function name to remove the function whitelist.) Disabling a validation check also ignores any custom validation check for that type!
 - Fixed issue with toolkit giving incorrect error and exception messages
 - Added ability for sandbox to overwrite static type hints that are redefined to other class names (NOTE: All statically referenced class/interface/trait names are treated as classes by the parser and the sandbox, therefore they must be redefined via define_class())
 - Updated documentation
 
-##05/06/2014
+## 05/06/2014
 - Corrected defined alias case-sensitivity issue (see: issue #10)
 
-##03/19/2014
+## 03/19/2014
 - API CHANGE: set_error_handler() and its related methods have been changed to set_validation_error_handler(), etc. because that more closely explains their purpose of handling validation errors in the sandbox
 - set_error_handler() its related methods now represent a new error handling mechanism that replicates PHP's set_error_handler() built-in functionality for the sandbox
 - set_exception_handler() and its related methods represent a new exception handling mechanism that replicates PHP's set_exception_handler() built-in functionality for the sandbox
@@ -28,42 +28,42 @@
 - Addressed issue where functions expecting float or int values passed as strings would throw errors
 - You can now specify an unlimited number of parameters for all whitelist_*, blacklist_*, etc. methods etc for _superglobal. This works the same as passing an array of parameters.
 
-##03/10/2014
+## 03/10/2014
 - Addressed potential vulnerabilities related to SandboxedStrings where sandboxed code could manipulate the strings in a way that could defeat their protection
 - Solved errors from casting sandboxed strings to int
 - Overwrote some internal PHP functions to further mask SandboxedStrings from the sandboxed code and prevent type-checking errors
 - Added more tests related to SandboxedStrings
 - Made some minor tweaks to PHPSandbox Toolkit
 
-##03/05/2014
+## 03/05/2014
 - Corrected an issue where the sandbox variable could be accessed from within the sandbox in PHP 5.4+
 
-##03/03/2014
+## 03/03/2014
 - Implemented function checking mechanism for callbacks, which should now obey function whitelists and blacklists
 - Replaced passed sandbox instance variable with static method call that allows the sandbox to be accessed for validation within sandboxed functions and closures
 - Added overwritten var_dump, print_r and var_export methods that automatically hide the sandbox instance and return the string value of sandboxed strings
 
-##01/30/2014
+## 01/30/2014
 - Implemented overhaul of error handling system. Can now specify a custom error handler to intercept thrown exceptions.
 
-##12/09/2013
+## 12/09/2013
 - Added ability to define custom validation functions for fine-grained control of the sandbox elements
 - Added capture_output flag to indicate whether to capture and return output of sandbox execution via output buffering
 - Added restore_error_level flag to indicate whether the to restore error level after setting custom error level in sandbox
 
-##08/15/2013
+## 08/15/2013
 - Added support for PHP 5.5. and new allow_generators flag for configuring the sandbox to enable or disable PHP 5.5 generators
 
-##03/04/2013
+## 03/04/2013
 - Added the ability to redefine classes, interfaces and traits
 
-##03/03/2013
+## 03/03/2013
 
 - Major updates to dynamic demonstrations system, not know as the PHPSandbox Toolkit. Allows for almost unlimited configuration of PHPSandbox environments
 - PHPSandbox class now supports importing JSON template configurations, serialization, and defining callables for superglobals and magic constants
 - API documentation is complete, PHPUnit testing is initialized. Toolkit has its own help system, utilizing the fully written INSTRUCTIONS.html
 
-##03/01/2013
+## 03/01/2013
 
 - Early version of dynamic demonstration system added to /demos
 - Supports configuring and testing sandboxes from local PHP server without the necessity of coding specific demos

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![PHPSandbox](http://phpsandbox.org/images/logo.png)
 
-##DEPRECATED: The PHPSandbox project has transfered to [Corveda/PHPSandbox](https://github.com/Corveda/PHPSandbox) and will be actively maintained there. This branch is no longer being actively maintained. Update your dependencies as follows:
+## DEPRECATED: The PHPSandbox project has transfered to [Corveda/PHPSandbox](https://github.com/Corveda/PHPSandbox) and will be actively maintained there. This branch is no longer being actively maintained. Update your dependencies as follows:
 
     {
         "require": {
@@ -9,7 +9,7 @@
     }
 
 
-##A full-scale PHP 5.3.2+ sandbox class that utilizes [PHP-Parser](https://github.com/nikic/PHP-Parser) to prevent sandboxed code from running unsafe code.
+## A full-scale PHP 5.3.2+ sandbox class that utilizes [PHP-Parser](https://github.com/nikic/PHP-Parser) to prevent sandboxed code from running unsafe code.
 
 It also utilizes [FunctionParser](https://github.com/jeremeamia/FunctionParser) to disassemble callables passed to the sandbox, so that PHP callables can also be run in sandboxes without first converting them into strings.
 
@@ -20,7 +20,7 @@ It also utilizes [FunctionParser](https://github.com/jeremeamia/FunctionParser) 
 [![Build Status](https://travis-ci.org/fieryprophet/php-sandbox.png?branch=master)](https://travis-ci.org/fieryprophet/php-sandbox) [![Latest Stable Version](https://poser.pugx.org/fieryprophet/php-sandbox/v/stable.png)](https://packagist.org/packages/fieryprophet/php-sandbox) [![Total Downloads](https://poser.pugx.org/fieryprophet/php-sandbox/downloads.png)](https://packagist.org/packages/fieryprophet/php-sandbox) [![Latest Unstable Version](https://poser.pugx.org/fieryprophet/php-sandbox/v/unstable.png)](https://packagist.org/packages/fieryprophet/php-sandbox) [![License](https://poser.pugx.org/fieryprophet/php-sandbox/license.png)](https://packagist.org/packages/fieryprophet/php-sandbox)
 [![Dependency Status](https://www.versioneye.com/php/fieryprophet:php-sandbox/1.3.10/badge.svg)](https://www.versioneye.com/php/fieryprophet:php-sandbox/1.3.10)
 
-##Features:
+## Features:
 
 - Finegrained whitelisting and blacklisting, with sensible defaults configured.
 - **Includes dynamic demonstration system that allows for local testing of custom sandbox configurations**
@@ -38,7 +38,7 @@ It also utilizes [FunctionParser](https://github.com/jeremeamia/FunctionParser) 
 - Can specify a validation error handler to intercept thrown validation errors and handle them with custom logic.
 - **Can intercept callbacks and validate them against function whitelists and blacklists, even if they are called as strings**
 
-##Example usage:
+## Example usage:
 
     function test($string){
         return 'Hello ' . $string;
@@ -52,7 +52,7 @@ It also utilizes [FunctionParser](https://github.com/jeremeamia/FunctionParser) 
 
     var_dump($result);  //Hello world
 
-##Custom validation example:
+## Custom validation example:
 
     function custom_func(){
         echo 'I am valid!';
@@ -68,7 +68,7 @@ It also utilizes [FunctionParser](https://github.com/jeremeamia/FunctionParser) 
     });
     //echoes "I am valid!"
 
-##Custom validation error handler example:
+## Custom validation error handler example:
 
     $sandbox = new PHPSandbox\PHPSandbox;
     //this will intercept parser validation errors and quietly exit, otherwise it will throw the validation error
@@ -81,7 +81,7 @@ It also utilizes [FunctionParser](https://github.com/jeremeamia/FunctionParser) 
     $sandbox->execute('<?php i am malformed PHP code; ?>');
     //does nothing
 
-##Disable validation example:
+## Disable validation example:
 
     $sandbox = new PHPSandbox\PHPSandbox;
     //this will disable function validation
@@ -89,14 +89,14 @@ It also utilizes [FunctionParser](https://github.com/jeremeamia/FunctionParser) 
     $sandbox->execute('<?php echo system("ping google.com"); ?>');
     //Pinging google.com. . .
 
-##Requirements
+## Requirements
 
 - PHP 5.3.2+
 - [PHP-Parser](https://github.com/nikic/PHP-Parser)
 - [FunctionParser](https://github.com/jeremeamia/FunctionParser) (if you wish to use closures)
 - PHP should be compiled with *--enable-tokenizer* option (it typically is)
 
-##Installation
+## Installation
 
 To install using [composer](http://getcomposer.org/), simply add the following to your composer.json file in the root of your project:
 
@@ -109,7 +109,7 @@ To install using [composer](http://getcomposer.org/), simply add the following t
 
 Then run *composer install --dry-run* to check for any potential problems, and *composer install* to install.
 
-##LICENSE
+## LICENSE
 
     Copyright (c) 2013-2015 by Elijah Horton (fieryprophet [at] yahoo.com)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
